### PR TITLE
feat: configurable embedding dimensions for Gemini

### DIFF
--- a/cmd/keyoku-server/config.go
+++ b/cmd/keyoku-server/config.go
@@ -23,8 +23,9 @@ type ServerConfig struct {
 	OpenAIBaseURL      string `json:"openai_base_url"`
 	AnthropicBaseURL   string `json:"anthropic_base_url"`
 	EmbeddingBaseURL   string `json:"embedding_base_url"`
-	EmbeddingProvider  string `json:"embedding_provider"`
-	EmbeddingModel     string `json:"embedding_model"`
+	EmbeddingProvider   string `json:"embedding_provider"`
+	EmbeddingModel      string `json:"embedding_model"`
+	EmbeddingDimensions int    `json:"embedding_dimensions"`
 	SchedulerEnabled   *bool  `json:"scheduler_enabled"`
 	QuietHoursEnabled  *bool  `json:"quiet_hours_enabled"`
 	QuietHourStart     *int   `json:"quiet_hour_start"`
@@ -99,6 +100,11 @@ func LoadServerConfig(path string) (ServerConfig, error) {
 	}
 	if v := os.Getenv("KEYOKU_EMBEDDING_MODEL"); v != "" {
 		cfg.EmbeddingModel = v
+	}
+	if v := os.Getenv("KEYOKU_EMBEDDING_DIMENSIONS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			cfg.EmbeddingDimensions = n
+		}
 	}
 	if v := os.Getenv("OPENAI_BASE_URL"); v != "" {
 		cfg.OpenAIBaseURL = v
@@ -195,6 +201,9 @@ func (sc ServerConfig) ToKeyokuConfig() keyoku.Config {
 	}
 	if sc.EmbeddingModel != "" {
 		cfg.EmbeddingModel = sc.EmbeddingModel
+	}
+	if sc.EmbeddingDimensions > 0 {
+		cfg.EmbeddingDimensions = sc.EmbeddingDimensions
 	}
 	if sc.OpenAIBaseURL != "" {
 		cfg.OpenAIBaseURL = sc.OpenAIBaseURL

--- a/config.go
+++ b/config.go
@@ -26,8 +26,9 @@ type Config struct {
 	EmbeddingBaseURL string // e.g., custom embedding endpoint (defaults to OpenAI)
 
 	// Embeddings
-	EmbeddingProvider string // "openai" (default), "gemini"
-	EmbeddingModel    string // default: "text-embedding-3-small" (openai) or "gemini-embedding-001" (gemini)
+	EmbeddingProvider   string // "openai" (default), "gemini"
+	EmbeddingModel      string // default: "text-embedding-3-small" (openai) or "gemini-embedding-001" (gemini)
+	EmbeddingDimensions int    // override output dimensions (0 = use model default; Gemini supports truncation via OutputDimensionality)
 
 	// Behavior
 	MaxExtractTokens int // default: 4000

--- a/embedder/gemini.go
+++ b/embedder/gemini.go
@@ -18,13 +18,18 @@ type GeminiEmbedder struct {
 }
 
 // NewGemini creates a Gemini embedder using the google.golang.org/genai SDK.
-func NewGemini(apiKey, model string) (*GeminiEmbedder, error) {
+// If overrideDims > 0, the API is asked to truncate output to that many dimensions
+// (via OutputDimensionality), and the HNSW index is sized accordingly.
+func NewGemini(apiKey, model string, overrideDims int) (*GeminiEmbedder, error) {
 	if model == "" {
 		model = "gemini-embedding-001"
 	}
 	dims := 3072 // gemini-embedding-001 default
 	if model == "text-embedding-004" {
 		dims = 768
+	}
+	if overrideDims > 0 {
+		dims = overrideDims
 	}
 	ctx := context.Background()
 	client, err := genai.NewClient(ctx, &genai.ClientConfig{
@@ -57,7 +62,12 @@ func (g *GeminiEmbedder) EmbedBatch(ctx context.Context, texts []string) ([][]fl
 		contents[i] = genai.NewContentFromText(t, "")
 	}
 
-	resp, err := g.client.Models.EmbedContent(ctx, g.model, contents, nil)
+	var ecCfg *genai.EmbedContentConfig
+	if g.dims > 0 {
+		od := int32(g.dims)
+		ecCfg = &genai.EmbedContentConfig{OutputDimensionality: &od}
+	}
+	resp, err := g.client.Models.EmbedContent(ctx, g.model, contents, ecCfg)
 	if err != nil {
 		return nil, fmt.Errorf("Gemini embedding failed: %w", err)
 	}

--- a/embedder/gemini_test.go
+++ b/embedder/gemini_test.go
@@ -21,7 +21,7 @@ func getGeminiKey(t *testing.T) string {
 
 func TestGeminiEmbedder_NewGemini(t *testing.T) {
 	t.Run("default model dimensions", func(t *testing.T) {
-		emb, err := NewGemini("fake-key", "")
+		emb, err := NewGemini("fake-key", "", 0)
 		if err != nil {
 			t.Fatalf("NewGemini error = %v", err)
 		}
@@ -31,7 +31,7 @@ func TestGeminiEmbedder_NewGemini(t *testing.T) {
 	})
 
 	t.Run("custom model", func(t *testing.T) {
-		emb, err := NewGemini("fake-key", "gemini-embedding-001")
+		emb, err := NewGemini("fake-key", "gemini-embedding-001", 0)
 		if err != nil {
 			t.Fatalf("NewGemini error = %v", err)
 		}

--- a/engine/agent_stress_test.go
+++ b/engine/agent_stress_test.go
@@ -1610,7 +1610,7 @@ func runAgentStressForStack(t *testing.T, spec stackSpec) *agentStressReport {
 	case "openai":
 		emb = embedder.NewOpenAI(embKey, spec.embModel)
 	case "gemini":
-		emb, err = embedder.NewGemini(embKey, spec.embModel)
+		emb, err = embedder.NewGemini(embKey, spec.embModel, 0)
 		if err != nil {
 			t.Fatalf("  failed to create Gemini embedder: %v", err)
 		}

--- a/engine/cognitive_stress_test.go
+++ b/engine/cognitive_stress_test.go
@@ -184,7 +184,7 @@ func initEmbedder(t *testing.T) embedder.Embedder {
 	t.Helper()
 
 	if key := os.Getenv("GEMINI_API_KEY"); key != "" {
-		emb, err := embedder.NewGemini(key, "gemini-embedding-001")
+		emb, err := embedder.NewGemini(key, "gemini-embedding-001", 0)
 		if err != nil {
 			t.Fatalf("failed to create Gemini embedder: %v", err)
 		}

--- a/heartbeat_recall_test.go
+++ b/heartbeat_recall_test.go
@@ -105,7 +105,7 @@ func newRecallHarness(t *testing.T) *heartbeatRecallHarness {
 
 	if geminiKey != "" {
 		var err error
-		emb, err = embedder.NewGemini(geminiKey, "gemini-embedding-001")
+		emb, err = embedder.NewGemini(geminiKey, "gemini-embedding-001", 0)
 		if err != nil {
 			t.Fatalf("failed to create Gemini embedder: %v", err)
 		}

--- a/heartbeat_stress_test.go
+++ b/heartbeat_stress_test.go
@@ -197,7 +197,7 @@ func newHeartbeatStressHarness(t *testing.T) *heartbeatStressHarness {
 
 	if geminiKey != "" {
 		var err error
-		emb, err = embedder.NewGemini(geminiKey, "gemini-embedding-001")
+		emb, err = embedder.NewGemini(geminiKey, "gemini-embedding-001", 0)
 		if err != nil {
 			t.Fatalf("failed to create Gemini embedder: %v", err)
 		}

--- a/keyoku.go
+++ b/keyoku.go
@@ -145,7 +145,7 @@ func New(cfg Config) (*Keyoku, error) {
 	switch embProvider {
 	case "gemini", "google":
 		var embErr error
-		emb, embErr = embedder.NewGemini(cfg.GeminiAPIKey, cfg.EmbeddingModel)
+		emb, embErr = embedder.NewGemini(cfg.GeminiAPIKey, cfg.EmbeddingModel, cfg.EmbeddingDimensions)
 		if embErr != nil {
 			return nil, fmt.Errorf("failed to create Gemini embedder: %w", embErr)
 		}


### PR DESCRIPTION
## Summary

Gemini embedding models (e.g. `gemini-embedding-001`) output 3072-dimensional vectors by default, but Keyoku's HNSW index defaults to 1536 dimensions. This mismatch requires either rebuilding the index or truncating embeddings client-side.

This PR adds a `EmbeddingDimensions` config option that:

- Passes `OutputDimensionality` to the Gemini `EmbedContent` API, so the server returns natively truncated vectors (no precision loss from naive client-side slicing)
- Sizes the HNSW index to match the requested dimensions

**Configuration:**
- Env var: `KEYOKU_EMBEDDING_DIMENSIONS=1536`
- JSON config: `"embedding_dimensions": 1536`
- Default: `0` (use model default, fully backward compatible)

## Changes

- `embedder/gemini.go`: `NewGemini()` accepts `overrideDims int`; sets `EmbedContentConfig.OutputDimensionality` when > 0
- `config.go`: Added `EmbeddingDimensions` field to `Config`
- `keyoku.go`: Wires `cfg.EmbeddingDimensions` through to `NewGemini()`
- `cmd/keyoku-server/config.go`: Added server config field, env var parsing, and `ToKeyokuConfig()` mapping
- Test files: Updated all `NewGemini()` call sites with `0` (no dimension override)

## Test plan

- [ ] Existing tests pass (all call sites updated with backward-compatible `0` arg)
- [ ] Manual verification with `KEYOKU_EMBEDDING_DIMENSIONS=1536` and `gemini-embedding-001` confirms 1536-dim vectors returned